### PR TITLE
#34 - fix parallel checksum calculation

### DIFF
--- a/src/main/java/cz/sparko/boxitory/factory/HashServiceFactory.java
+++ b/src/main/java/cz/sparko/boxitory/factory/HashServiceFactory.java
@@ -12,14 +12,13 @@ import java.security.NoSuchAlgorithmException;
 
 public class HashServiceFactory {
 
-    public static HashService createHashService(AppProperties appProperties, HashStore hashStore) throws
-            NoSuchAlgorithmException {
+    public static HashService createHashService(AppProperties appProperties, HashStore hashStore) {
         HashAlgorithm algorithm = appProperties.getChecksum();
         if (algorithm == HashAlgorithm.DISABLED) {
             return new NoopHashService();
         } else {
-            return new FilesystemDigestHashService(MessageDigest.getInstance(algorithm.getMessageDigestName()),
-                    appProperties.getChecksum(), appProperties.getChecksum_buffer_size(), hashStore);
+            return new FilesystemDigestHashService(appProperties.getChecksum(), appProperties.getChecksum_buffer_size(),
+                                                   hashStore);
         }
     }
 }

--- a/src/main/java/cz/sparko/boxitory/service/filesystem/FilesystemDigestHashService.java
+++ b/src/main/java/cz/sparko/boxitory/service/filesystem/FilesystemDigestHashService.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
 
 /**
@@ -23,53 +24,48 @@ public class FilesystemDigestHashService implements HashService {
 
     private static final int DEFAULT_STREAM_BUFFER_LENGTH = 1024;
 
-    private final MessageDigest messageDigest;
     private final int streamBufferLength;
     private final HashStore hashStore;
     private final HashAlgorithm hashAlgorithm;
 
     /**
-     * @param messageDigest      instance of {@link MessageDigest} which is used to calculate hashes
      * @param hashAlgorithm      algorithm used to calculate hashes
      * @param streamBufferLength buffer used when calculating hashes
      * @param hashStore          store used to persist already calculated hashes
      */
-    public FilesystemDigestHashService(MessageDigest messageDigest, HashAlgorithm hashAlgorithm,
-                                       int streamBufferLength, HashStore hashStore) {
+    public FilesystemDigestHashService(HashAlgorithm hashAlgorithm, int streamBufferLength, HashStore hashStore) {
         this.hashAlgorithm = hashAlgorithm;
-        this.messageDigest = messageDigest;
         this.streamBufferLength = streamBufferLength;
         this.hashStore = hashStore;
     }
 
     /**
-     * See {@link FilesystemDigestHashService#FilesystemDigestHashService(MessageDigest, HashAlgorithm, int, HashStore)}
+     * See {@link FilesystemDigestHashService#FilesystemDigestHashService(HashAlgorithm, int, HashStore)}
      * <p>
      * Uses {@link NoopHashStore} as store.
      */
-    public FilesystemDigestHashService(MessageDigest messageDigest, HashAlgorithm hashAlgorithm,
-                                       int streamBufferLength) {
-        this(messageDigest, hashAlgorithm, streamBufferLength, new NoopHashStore());
+    public FilesystemDigestHashService(HashAlgorithm hashAlgorithm, int streamBufferLength) {
+        this(hashAlgorithm, streamBufferLength, new NoopHashStore());
     }
 
     /**
-     * See {@link FilesystemDigestHashService#FilesystemDigestHashService(MessageDigest, HashAlgorithm, int, HashStore)}
+     * See {@link FilesystemDigestHashService#FilesystemDigestHashService(HashAlgorithm, int, HashStore)}
      * <p>
      * Uses {@link NoopHashStore} as store.
      * <br>
      * Uses {@link FilesystemDigestHashService#DEFAULT_STREAM_BUFFER_LENGTH} as {@code streamBufferLength}.
      */
-    public FilesystemDigestHashService(MessageDigest messageDigest, HashAlgorithm hashAlgorithm) {
-        this(messageDigest, hashAlgorithm, DEFAULT_STREAM_BUFFER_LENGTH, new NoopHashStore());
+    public FilesystemDigestHashService(HashAlgorithm hashAlgorithm) {
+        this(hashAlgorithm, DEFAULT_STREAM_BUFFER_LENGTH, new NoopHashStore());
     }
 
     /**
-     * See {@link FilesystemDigestHashService#FilesystemDigestHashService(MessageDigest, HashAlgorithm, int, HashStore)}
+     * See {@link FilesystemDigestHashService#FilesystemDigestHashService(HashAlgorithm, int, HashStore)}
      * <p>
      * Uses {@link FilesystemDigestHashService#DEFAULT_STREAM_BUFFER_LENGTH} as {@code streamBufferLength}.
      */
-    public FilesystemDigestHashService(MessageDigest messageDigest, HashAlgorithm hashAlgorithm, HashStore hashStore) {
-        this(messageDigest, hashAlgorithm, DEFAULT_STREAM_BUFFER_LENGTH, hashStore);
+    public FilesystemDigestHashService(HashAlgorithm hashAlgorithm, HashStore hashStore) {
+        this(hashAlgorithm, DEFAULT_STREAM_BUFFER_LENGTH, hashStore);
     }
 
     @Override
@@ -86,20 +82,25 @@ public class FilesystemDigestHashService implements HashService {
     }
 
     private String calculateHash(String box) {
-        LOG.debug("calculating [{}] hash for box [{}]", hashAlgorithm.name(), box);
-        try (InputStream boxDataStream = Files.newInputStream(new File(box).toPath());
-             InputStream digestInputStream = new DigestInputStream(boxDataStream, messageDigest)) {
-            LOG.trace("buffering box data (buffer size [{}]b) ...", streamBufferLength);
-            final byte[] buffer = new byte[streamBufferLength];
-            //noinspection StatementWithEmptyBody
-            while (digestInputStream.read(buffer) > 0) ;
-        } catch (IOException e) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(hashAlgorithm.getMessageDigestName());
+            LOG.debug("calculating [{}] hash for box [{}]", hashAlgorithm.name(), box);
+            try (InputStream boxDataStream = Files.newInputStream(new File(box).toPath());
+                 InputStream digestInputStream = new DigestInputStream(boxDataStream, messageDigest)) {
+                LOG.trace("buffering box data (buffer size [{}]b) ...", streamBufferLength);
+                final byte[] buffer = new byte[streamBufferLength];
+                //noinspection StatementWithEmptyBody
+                while (digestInputStream.read(buffer) > 0) ;
+
+                return getHash(messageDigest.digest());
+            }
+        } catch (IOException | NoSuchAlgorithmException e) {
             LOG.error("Error during processing file [{}], message: [{}]", box, e.getMessage());
             throw new RuntimeException(
                     "Error while getting checksum for file " + box + " reason: " + e.getMessage(), e);
         }
 
-        return getHash(messageDigest.digest());
+
     }
 
     private String getHash(byte[] digestBytes) {
@@ -109,20 +110,25 @@ public class FilesystemDigestHashService implements HashService {
     @Override
     public String toString() {
         return "FilesystemDigestHashService{" +
-                "messageDigest=" + messageDigest +
+                "streamBufferLength=" + streamBufferLength +
+                ", hashStore=" + hashStore +
+                ", hashAlgorithm=" + hashAlgorithm +
                 '}';
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         FilesystemDigestHashService that = (FilesystemDigestHashService) o;
-        return messageDigest.getAlgorithm().equals(that.messageDigest.getAlgorithm());
+        return streamBufferLength == that.streamBufferLength &&
+                Objects.equals(hashStore, that.hashStore) &&
+                hashAlgorithm == that.hashAlgorithm;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(messageDigest);
+
+        return Objects.hash(streamBufferLength, hashStore, hashAlgorithm);
     }
 }

--- a/src/main/java/cz/sparko/boxitory/service/filesystem/FilesystemDigestHashService.java
+++ b/src/main/java/cz/sparko/boxitory/service/filesystem/FilesystemDigestHashService.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Objects;
 
 /**
  * This implementation of {@link HashService} calculates checksums from files on filesystem using {@link MessageDigest}
@@ -114,21 +113,5 @@ public class FilesystemDigestHashService implements HashService {
                 ", hashStore=" + hashStore +
                 ", hashAlgorithm=" + hashAlgorithm +
                 '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        FilesystemDigestHashService that = (FilesystemDigestHashService) o;
-        return streamBufferLength == that.streamBufferLength &&
-                Objects.equals(hashStore, that.hashStore) &&
-                hashAlgorithm == that.hashAlgorithm;
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(streamBufferLength, hashStore, hashAlgorithm);
     }
 }

--- a/src/main/java/cz/sparko/boxitory/service/noop/NoopHashService.java
+++ b/src/main/java/cz/sparko/boxitory/service/noop/NoopHashService.java
@@ -14,9 +14,4 @@ public class NoopHashService implements HashService {
     public String getChecksum(String box) {
         return null;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj.getClass().getName().equals(NoopHashService.class.getName());
-    }
 }

--- a/src/main/java/cz/sparko/boxitory/service/noop/NoopHashStore.java
+++ b/src/main/java/cz/sparko/boxitory/service/noop/NoopHashStore.java
@@ -17,4 +17,9 @@ public class NoopHashStore implements HashStore {
     public Optional<String> loadHash(String box, HashAlgorithm algorithm) {
         return Optional.empty();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj.getClass().getName().equals(NoopHashStore.class.getName());
+    }
 }

--- a/src/main/java/cz/sparko/boxitory/service/noop/NoopHashStore.java
+++ b/src/main/java/cz/sparko/boxitory/service/noop/NoopHashStore.java
@@ -17,9 +17,4 @@ public class NoopHashStore implements HashStore {
     public Optional<String> loadHash(String box, HashAlgorithm algorithm) {
         return Optional.empty();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj.getClass().getName().equals(NoopHashStore.class.getName());
-    }
 }

--- a/src/test/java/cz/sparko/boxitory/service/FilesystemDigestHashServiceTest.java
+++ b/src/test/java/cz/sparko/boxitory/service/FilesystemDigestHashServiceTest.java
@@ -14,8 +14,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
 import static cz.sparko.boxitory.service.HashService.HashAlgorithm.MD5;
@@ -79,9 +77,8 @@ public class FilesystemDigestHashServiceTest {
 
     @Test(dataProvider = "filesAndHashes")
     public void givenHashService_whenGetChecksum_thenChecksumsAreEquals(
-            HashAlgorithm algorithm, File file, String expectedChecksum) throws NoSuchAlgorithmException {
-        HashService hashService = new FilesystemDigestHashService(
-                MessageDigest.getInstance(algorithm.getMessageDigestName()), algorithm, 1024);
+            HashAlgorithm algorithm, File file, String expectedChecksum) {
+        HashService hashService = new FilesystemDigestHashService(algorithm, 1024);
 
         String checksum = hashService.getChecksum(file.getAbsolutePath());
 
@@ -89,8 +86,7 @@ public class FilesystemDigestHashServiceTest {
     }
 
     @Test
-    public void givenHashService_whenLoadHashReturnsHash_thenHashStoreLoadAndPersistAreCalled()
-            throws NoSuchAlgorithmException {
+    public void givenHashService_whenLoadHashReturnsHash_thenHashStoreLoadAndPersistAreCalled() {
         final String box = "box";
         final String hash = "hash";
         final HashAlgorithm algorithm = MD5;
@@ -101,8 +97,7 @@ public class FilesystemDigestHashServiceTest {
         HashStore hashStore = Mockito.mock(HashStore.class);
         Mockito.when(hashStore.loadHash(box, algorithm)).thenReturn(Optional.of(hash));
 
-        HashService hashService = new FilesystemDigestHashService(
-                MessageDigest.getInstance(algorithm.getMessageDigestName()), algorithm, hashStore);
+        HashService hashService = new FilesystemDigestHashService(algorithm, hashStore);
         hashService.getChecksum(box);
 
         Mockito.verify(hashStore, Mockito.times(1)).loadHash(box, algorithm);

--- a/src/test/java/cz/sparko/boxitory/service/HashServiceFactoryTest.java
+++ b/src/test/java/cz/sparko/boxitory/service/HashServiceFactoryTest.java
@@ -10,10 +10,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
-
 import static cz.sparko.boxitory.service.HashService.HashAlgorithm.DISABLED;
 import static cz.sparko.boxitory.service.HashService.HashAlgorithm.MD5;
 import static cz.sparko.boxitory.service.HashService.HashAlgorithm.SHA1;
@@ -24,19 +20,18 @@ import static org.testng.Assert.assertEquals;
 public class HashServiceFactoryTest {
 
     @DataProvider
-    public Object[][] hashServiceTypes() throws NoSuchAlgorithmException {
+    public Object[][] hashServiceTypes() {
         return new Object[][]{
-                {MD5, new FilesystemDigestHashService(MessageDigest.getInstance("MD5"), MD5)},
-                {SHA1, new FilesystemDigestHashService(MessageDigest.getInstance("SHA-1"), SHA1)},
-                {SHA256, new FilesystemDigestHashService(MessageDigest.getInstance("SHA-256"), SHA256)},
+                {MD5, new FilesystemDigestHashService(MD5)},
+                {SHA1, new FilesystemDigestHashService(SHA1)},
+                {SHA256, new FilesystemDigestHashService(SHA256)},
                 {DISABLED, new NoopHashService()}
         };
     }
 
     @Test(dataProvider = "hashServiceTypes")
     public void givenFactory_whenCreateHashService_thenGetExpectedInstance(HashAlgorithm type,
-                                                                           HashService expectedService)
-            throws NoSuchAlgorithmException {
+                                                                           HashService expectedService) {
         AppProperties appProperties = new AppProperties();
         appProperties.setChecksum(type);
         HashService hashService = HashServiceFactory.createHashService(appProperties, new NoopHashStore());

--- a/src/test/java/cz/sparko/boxitory/service/HashServiceFactoryTest.java
+++ b/src/test/java/cz/sparko/boxitory/service/HashServiceFactoryTest.java
@@ -36,6 +36,6 @@ public class HashServiceFactoryTest {
         appProperties.setChecksum(type);
         HashService hashService = HashServiceFactory.createHashService(appProperties, new NoopHashStore());
 
-        assertEquals(hashService, expectedService);
+        assertEquals(hashService.getHashType(), expectedService.getHashType());
     }
 }

--- a/src/test/java/cz/sparko/boxitory/test/e2e/ParallelChecksumCalcTest.java
+++ b/src/test/java/cz/sparko/boxitory/test/e2e/ParallelChecksumCalcTest.java
@@ -1,0 +1,75 @@
+package cz.sparko.boxitory.test.e2e;
+
+import org.springframework.test.context.TestPropertySource;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@TestPropertySource(properties = {"box.checksum=md5", "box.checksum_persist=true"})
+public class ParallelChecksumCalcTest extends AbstractIntegrationTest {
+    private final String VM1 = "vm1";
+    private final String VM2 = "vm2";
+    private final String VM1_1_VBOX = VM1 + "_1_virtualbox.box";
+    private final String VM2_1_VBOX = VM2 + "_1_virtualbox.box";
+
+    private final String EXPECTED_VM1BOX_CHECKSUM = "6dd69c522eac6e1689f4896d96db7c95";
+    private final String EXPECTED_VM2BOX_CHECKSUM = "6b21c4a111ac178feacf9ec9d0c71f17";
+
+    @Override
+    public void createFolderStructure() throws IOException {
+        createRepositoryDir();
+        File vm1Dir = createDirInRepository(VM1);
+        File vm2Dir = createDirInRepository(VM2);
+        File vm1box = createFile(vm1Dir.getPath() + File.separator + VM1_1_VBOX);
+        File vm2box = createFile(vm2Dir.getPath() + File.separator + VM2_1_VBOX);
+
+        try (FileWriter vm1boxWriter = new FileWriter(vm1box);
+             FileWriter vm2boxWriter = new FileWriter(vm2box)) {
+            for (int i = 0; i < 1_000_000; i++) {
+                vm1boxWriter.append(String.valueOf(i));
+            }
+            for (int i = 0; i < 1_000; i++) {
+                vm2boxWriter.append(String.valueOf(i));
+            }
+        }
+    }
+
+    @Test
+    public void givenTwoBoxes_whenCalculateChecksumParallel_thenChecksumIsCorrectlyCalculated() throws
+            Exception {
+        Thread requestVm1 = new Thread(() -> {
+            try {
+                mockMvc.perform(get("/" + VM2));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        Thread requestVm2 = new Thread(() -> {
+            try {
+                mockMvc.perform(get("/" + VM2));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        requestVm1.start();
+        requestVm2.start();
+
+        requestVm1.join();
+        requestVm2.join();
+
+        mockMvc.perform(get("/" + VM1))
+                .andDo(print())
+                .andExpect(jsonPath("$.versions[0].providers[0].checksum", is(EXPECTED_VM1BOX_CHECKSUM)));
+        mockMvc.perform(get("/" + VM2))
+                .andDo(print())
+                .andExpect(jsonPath("$.versions[0].providers[0].checksum", is(EXPECTED_VM2BOX_CHECKSUM)));
+    }
+}


### PR DESCRIPTION
fixed bug with parallel checksum calculation.
It was caused by one instance of `MessageDigest` in `FilesystemDigestHashService`. When multiple checksum calculations were performed in parallel, they were calculated with the same instance of `MessageDigest`, which is not concurrent, thus checksums were calculated wrong and failed on `ArrayIndexOfBoundException`