### PR TITLE
Added EE modules missing in jdk11, rebranded to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>2.5.5</version>
         <relativePath />
     </parent>
 
@@ -59,8 +59,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
 
-        <testng.version>6.11</testng.version>
-        <commons-io.version>2.7</commons-io.version>
+        <testng.version>7.5</testng.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,45 @@
             <optional>true</optional>
         </dependency>
 
+        <!--java EE -->
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>3.0.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!--java EE -->
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/cz/sparko/boxitory/service/filesystem/FilesystemDigestHashService.java
+++ b/src/main/java/cz/sparko/boxitory/service/filesystem/FilesystemDigestHashService.java
@@ -6,7 +6,7 @@ import cz.sparko.boxitory.service.noop.NoopHashStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/cz/sparko/boxitory/test/e2e/AbstractIntegrationTest.java
+++ b/src/test/java/cz/sparko/boxitory/test/e2e/AbstractIntegrationTest.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 @ContextConfiguration(classes = App.class)
 @WebMvcTest(controllers = {BoxRestController.class, DownloadController.class, BoxController.class})
-@AutoConfigureMockMvc(secure = false)
+@AutoConfigureMockMvc()
 @TestPropertySource(locations = "classpath:test.properties")
 @Test(groups = "e2e")
 public abstract class AbstractIntegrationTest extends AbstractTestNGSpringContextTests {


### PR DESCRIPTION
Note, that trhis now have test failures in mockit using classes
```
Underlying exception : java.lang.UnsupportedOperationException: Cannot define class using reflection
	at cz.sparko.boxitory.service.FilesystemDigestHashServiceTest.givenHashService_whenLoadHashReturnsHash_thenHashStoreLoadIsCalled(FilesystemDigestHashServiceTest.java:118)
Caused by: java.lang.UnsupportedOperationException: Cannot define class using reflection
	at cz.sparko.boxitory.service.FilesystemDigestHashServiceTest.givenHashService_whenLoadHashReturnsHash_thenHashStoreLoadIsCalled(FilesystemDigestHashServiceTest.java:118)
Caused by: java.lang.IllegalStateException: Could not find sun.misc.Unsafe
	at cz.sparko.boxitory.service.FilesystemDigestHashServiceTest.givenHashService_whenLiveHashCalculationIsTurnOffAndLoadHashReturnsHash_thenHashStoreLoadIsCalled(FilesystemDigestHashServiceTest.java:156)
Caused by: java.lang.NoSuchMethodException: sun.misc.Unsafe.defineClass(java.lang.String, [B, int, int, java.lang.ClassLoader, java.security.ProtectionDomain)
	at cz.sparko.boxitory.service.FilesystemDigestHashServiceTest.givenHashService_whenLiveHashCalculationIsTurnOffAndLoadHashReturnsHash_thenHashStoreLoadIsCalled(FilesystemDigestHashServiceTest.java:156)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   FilesystemDigestHashServiceTest.givenHashService_whenLiveHashCalculationIsTurnOffAndLoadHashReturnsHash_thenHashStoreLoadIsCalled:156 Mockito
[ERROR]   FilesystemDigestHashServiceTest.givenHashService_whenLoadHashNotReturnsHash_thenCalculateHashAndHashStorePersistAreCalled:137 Mockito
[ERROR]   FilesystemDigestHashServiceTest.givenHashService_whenLoadHashReturnsHash_thenHashStoreLoadIsCalled:118 Mockito
[INFO] 
```

work in progress